### PR TITLE
Use python2 specific shellbang via /usr/bin/env

### DIFF
--- a/blockstack_gpg/__init__.py
+++ b/blockstack_gpg/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-gpg

--- a/blockstack_gpg/gpg.py
+++ b/blockstack_gpg/gpg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     Blockstack-gpg

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from setuptools import setup, find_packages
 


### PR DESCRIPTION
Since not all Linux distributions link `/usr/bin/python` to `/usr/bin/python2` it is important to set the python version in the shellbang. Also using `/usr/bin/env` is more portable than `/usr/bin/python`